### PR TITLE
[springboard] Use LMResponseConsumePropertyList in IPC recieve function

### DIFF
--- a/springboard/SpringBoard.x
+++ b/springboard/SpringBoard.x
@@ -6,20 +6,14 @@ HBTSIMessageProvider *provider = nil;
 
 #pragma mark - IPC
 
-void ReceivedRelayedNotification(CFMachPortRef port, LMMessage *request, CFIndex size, void *info) {
+void ReceivedRelayedNotification(CFMachPortRef port, LMResponseBuffer *response, CFIndex size, void *info) {
 	// check that we aren’t being given a message that’s too short
 	if ((size_t)size < sizeof(LMMessage)) {
 		HBLogError(@"received a bad message? size = %li", size);
 		return;
 	}
 
-	// get the raw data sent
-	const void *rawData = LMMessageGetData(request);
-	size_t length = LMMessageGetDataLength(request);
-
-	// translate to NSData, then NSDictionary
-	CFDataRef data = CFDataCreateWithBytesNoCopy(kCFAllocatorDefault, (const UInt8 *)rawData, length, kCFAllocatorNull);
-	NSDictionary <NSString *, id> *userInfo = LMPropertyListForData((__bridge NSData *)data);
+	NSDictionary <NSString *, id> *userInfo = LMResponseConsumePropertyList(response);
 
 	// forward to the main controller
 	if (!provider) {


### PR DESCRIPTION
`LMResponseConsumePropertyList` converts the given response into a property list, just like the `ReceivedRelayedNotification` function implements. Additionally, this cleans up both the `data` and `request` (now `response` in this PR) being leaked. 

The `LMResponseBuffer` struct is the `LMMessage` struct with the buffer padding at the end. Due to C struct layouts, this allows them to be used interchangeably. The size check is still correct. 

Edit: Here's a link to the [implementation of LMResponseConsumePropertyList](/rpetrich/LightMessaging/blob/7a8e049c4059e1df1ff2f9669afa7ca4eedfb65b/LightMessaging.h#L391) checked out at the current theos/headers commit